### PR TITLE
Add the possibility to call different context menus depending on the context the user clicks on

### DIFF
--- a/src/ContextMenuTrigger.js
+++ b/src/ContextMenuTrigger.js
@@ -8,7 +8,10 @@ import { callIfExists, cssClasses } from './helpers';
 
 export default class ContextMenuTrigger extends Component {
     static propTypes = {
-        id: PropTypes.string.isRequired,
+        id: PropTypes.oneOfType([
+            PropTypes.string,
+            PropTypes.func
+        ]).isRequired,
         children: PropTypes.node.isRequired,
         attributes: PropTypes.object,
         collect: PropTypes.func,
@@ -99,11 +102,12 @@ export default class ContextMenuTrigger extends Component {
 
         hideMenu();
 
+        let id = typeof this.props.id === 'function' ? this.props.id(event) : this.props.id;
         let data = callIfExists(this.props.collect, this.props);
         let showMenuConfig = {
             position: { x, y },
             target: this.elem,
-            id: this.props.id,
+            id,
             data
         };
         if (data && (typeof data.then === 'function')) {


### PR DESCRIPTION
**New Feature: Description of Change**

This merge request adds the possibility to have different context menus showing up dependent on the context the use clicks. This allows to have the `ContextMenuTrigger` around non react components and still still have the flexibility to show the react-contextmenu. 

Scenario is using handontable component and wanting to have different context menus for rows/columns or cells. 

**Testing and Risks**

tested with a handontable component and have logic to show different context depending on the selection of the user. 

<!--template version="2.0" id="new_feature"-->